### PR TITLE
Add null logger

### DIFF
--- a/lib/ec2_meta.rb
+++ b/lib/ec2_meta.rb
@@ -5,6 +5,7 @@ require 'ec2_meta/client'
 require 'ec2_meta/loader'
 require 'ec2_meta/cache'
 require 'ec2_meta/fetcher'
+require 'ec2_meta/null_logger'
 require 'ec2_meta/apis/path.rb'
 
 require 'ec2_meta/apis/2014_02_25/base'
@@ -17,7 +18,7 @@ module Ec2Meta
 
     def client(options = {})
       opts = {
-        logger: Logger.new('/dev/null')
+        logger: ::Ec2Meta::NullLogger.new
       }.merge(options)
 
       Client.new(opts)

--- a/lib/ec2_meta/null_logger.rb
+++ b/lib/ec2_meta/null_logger.rb
@@ -1,0 +1,30 @@
+module Ec2Meta
+  class NullLogger
+    def debug(_progname = nil, &_block)
+    end
+
+    def debug?
+      false
+    end
+
+    def error(_progname = nil, &_block); end
+
+    def error?
+      false
+    end
+
+    def fatal(_progname = nil, &_block)
+    end
+
+    def fatal?
+      false
+    end
+
+    def info(_progname = nil, &_block)
+    end
+
+    def info?
+      false
+    end
+  end
+end

--- a/sample.rb
+++ b/sample.rb
@@ -3,14 +3,9 @@ require 'rubygems'
 require 'bundler/setup'
 
 require 'ec2_meta'
-
 require 'pry'
-require 'logger'
 
-logger = Logger.new('dev.log')
-logger.level = Logger::DEBUG
-
-client = Ec2Meta.client(logger: logger)
+client = Ec2Meta.client
 
 m = client.meta_data
 


### PR DESCRIPTION
Add null_logger.

This pull request enable users to use this Ec2Meta.client without logger.
