### PR TITLE
Utilize macs

### DIFF
--- a/lib/ec2_meta/apis/2014_02_25/meta_data.rb
+++ b/lib/ec2_meta/apis/2014_02_25/meta_data.rb
@@ -52,9 +52,34 @@ module Ec2Meta
 
       class Interfaces < Ec2Meta::Api::Path
         def macs(mac = nil)
-          return MacAddress.new(fetcher, new_prefix('macs'), mac) unless mac.nil?
+          case mac
+          when ::String
+            mac_address_for(mac)
+          when ::Integer
+            mac_address_at(mac)
+          when nil
+            fetch_macs
+          else
+            ::Kernel.raise ArgumentError, 'require String or Integer, or nil.'
+          end
+        end
 
-          fetch('macs')
+        private
+
+        def fetch_macs
+          result = fetch('macs/')
+          (result.nil? ? [] : result.split("\n").map { |v| v.chomp('/') })
+        end
+
+        def mac_address_for(address)
+          MacAddress.new(fetcher, new_prefix("macs/#{address}"), address)
+        end
+
+        def mac_address_at(position)
+          addr = fetch_macs.at(position)
+          return nil if addr.nil?
+
+          mac_address_for(addr)
         end
       end
 

--- a/sample.rb
+++ b/sample.rb
@@ -69,6 +69,14 @@ p m.local_ipv4
 puts '#mac'
 p m.mac
 
+puts '#network/interfaces/macs/0'
+#p m.network.interfaces.macs(0)
+
+puts '#network/interfaces/macs/0/device-number'
+p m.network.interfaces.macs(0).device_number
+
+p m.network.interfaces.macs(m.mac).device_number
+
 ### network/interfaces/macs/#{mac}
 puts '-------------'
 mac = m.network.interfaces.macs('mac')


### PR DESCRIPTION
`macs` method can receive String, Integer, nil.

When Argument is String, use as part of request path.
When Argument is Integer, use as position of mac address in mac address list.
When Argument is nil, fetch all of mac addresses.
